### PR TITLE
Rework get fru

### DIFF
--- a/rootfs/app/src/Controller/IpmiController.php
+++ b/rootfs/app/src/Controller/IpmiController.php
@@ -183,7 +183,7 @@ class IpmiController
                         $results = explode(PHP_EOL, $ret);
                         $device = $this->extractValuesFromResults($results);
 
-                        $ret = $this->runCommand(array_merge($cmd, ['-I', $ipmi_type, 'fru']));
+                        $ret = $this->runCommand(array_merge($cmd, ['-I', $ipmi_type, 'fru', 'print', '0']));
 
                         if ($ret) {
                             $results = explode(PHP_EOL, $ret);


### PR DESCRIPTION
I redid the reception of data from the fru, since it happens that there are several of them, and they may not be read correctly by ipmitool. Therefore, it is more logical to read only fru 0.